### PR TITLE
Fix/favourites

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -138,6 +138,7 @@ function App() {
                           setDashboard={setDashboard}
                           setCreatorID={setCreatorID}
                           creatorID={creatorID}
+                          setPlaylist={setPlaylist}
                         />
                       }
                     />

--- a/src/App.js
+++ b/src/App.js
@@ -58,6 +58,7 @@ const theme = createTheme({
 
 function App() {
   const [playlist, setPlaylist] = useState([]);
+  const [allCasts, setAllCasts] = useState([]);
   const [currentCast, setCurrentCast] = useState();
   /* ---------------------------- Dashboard toggle ---------------------------- */
   const [dashboard, setDashboard] = useState(true);
@@ -87,6 +88,7 @@ function App() {
       .get(GET_URL)
       .then((res) => {
         setPlaylist(res.data);
+        setAllCasts(res.data);
         setCurrentCast(playlist[0]);
       })
       .catch((e) => {
@@ -131,7 +133,7 @@ function App() {
                       path="*"
                       element={
                         <MinicastList
-                          minicasts={playlist}
+                          minicasts={allCasts}
                           onChange={setCurrentCast}
                           setDashboard={setDashboard}
                           setCreatorID={setCreatorID}
@@ -152,11 +154,12 @@ function App() {
                       path="/users/:id/minicasts/"
                       element={
                         <MinicastList
-                          minicasts={playlist}
+                          minicasts={allCasts}
                           onChange={setCurrentCast}
                           setDashboard={setDashboard}
                           setCreatorID={setCreatorID}
                           creatorID={creatorID}
+                          setPlaylist={setPlaylist}
                         />
                       }
                     />
@@ -164,7 +167,7 @@ function App() {
                     <Route
                       path="/favourites"
                       element={
-                        <Faves minicasts={playlist} onChange={setCurrentCast} />
+                        <Faves minicasts={playlist} onChange={setCurrentCast} setPlaylist={setPlaylist} />
                       }
                     />
                   </Routes>

--- a/src/App.js
+++ b/src/App.js
@@ -165,7 +165,7 @@ function App() {
                     />
 
                     <Route
-                      path="/favourites"
+                      path="users/:id/favourites"
                       element={
                         <Faves minicasts={playlist} onChange={setCurrentCast} setPlaylist={setPlaylist} />
                       }
@@ -241,7 +241,7 @@ function App() {
                           <div onClick={() => setCreatorID("")}>
                             {userID && (
                               <ListItemLink
-                                to="/favourites"
+                                to={`/users/${userID?.id}/favourites`}
                                 primary="Favourites"
                                 icon={null}
                                 button={true}

--- a/src/Components/Faves/index.js
+++ b/src/Components/Faves/index.js
@@ -1,11 +1,8 @@
 import Minicast from "../Minicast";
-import { useParams } from "react-router-dom";
 import axios from "axios";
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 
-function Faves(props) {
-  const [favecasts, setFavecasts] = useState([]);
-
+function Faves({ minicasts, onChange, setPlaylist }) {
   let GET_URL = "";
 
   let user = true;
@@ -26,25 +23,15 @@ function Faves(props) {
 
     axios
       .get(GET_URL)
-      // server will return an array. The array can be empty if there was no entry of user_id or minicast_id found
-      // which means the default fave state of false is appropriate (ie. the user never indicated the minicast was either favoured or not)
       .then((res) => {
-        setFavecasts(res.data);
+        setPlaylist(res.data);
       })
       .catch((e) => {
         console.log(e.message);
       });
-  });
+  }, []);
 
-  let faves = [];
-
-  for (const cast of favecasts) {
-    let id = cast?.minicast_id;
-    const result = props.minicasts.filter((cast) => cast.id == id);
-    faves.push(result[0]);
-  }
-
-  const MinicastArray = faves.map((minicast, index) => {
+  const MinicastArray = minicasts.map((minicast) => {
     return (
       <Minicast
         key={minicast.id}
@@ -54,7 +41,7 @@ function Faves(props) {
         audio_link={minicast.audio_link}
         banner_link={minicast.banner_link}
         avatar_link={minicast.avatar_link}
-        setCurrentCast={() => props.onChange(minicast)}
+        setCurrentCast={() => onChange(minicast)}
         handle={minicast.handle}
       />
     );

--- a/src/Components/Minicast/index.js
+++ b/src/Components/Minicast/index.js
@@ -10,6 +10,7 @@ import { CopyToClipboard } from "react-copy-to-clipboard";
 import Tooltip from "@mui/material/Tooltip";
 import { useState, useEffect } from "react";
 import axios from "axios";
+import { Link } from "react-router-dom"
 
 function Minicast(props) {
   const { handleFaceClick, user_id } = props;
@@ -89,6 +90,7 @@ function Minicast(props) {
       <CardActionArea onClick={props.setCurrentCast}>
         <CardHeader
           avatar={
+            <Link to ={`/users/${user_id}/minicasts`} >
             <Avatar
               src={props.avatar_link}
               onClick={() => handleFaceClick(user_id)}
@@ -97,7 +99,8 @@ function Minicast(props) {
                 zIndex: "999",
                 "&:hover": { transition: "0.2s", transform: "scale(1.3)" },
               }}
-            ></Avatar>
+            ></Avatar> 
+              </Link>
           }
           title={<Typography variant="h5">{props.title}</Typography>}
           subheader={`@${props.handle}`}

--- a/src/Components/MinicastList/index.js
+++ b/src/Components/MinicastList/index.js
@@ -32,6 +32,7 @@ function MinicastList(props) {
       setPlaylist(filteredArray);
     } else {
       setNewCastList(minicasts);
+      setPlaylist(minicasts);
     }
   }, [creatorID, minicasts]);
 

--- a/src/Components/MinicastList/index.js
+++ b/src/Components/MinicastList/index.js
@@ -3,9 +3,10 @@ import { useState, useEffect } from "react";
 import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
 import CreatorShow from "../CreatorShow";
+import { FilterAlt } from "@mui/icons-material";
 
 function MinicastList(props) {
-  const { creatorID, setCreatorID, minicasts } = props;
+  const { creatorID, setCreatorID, minicasts, setPlaylist } = props;
   const [newCastList, setNewCastList] = useState(minicasts);
 
   useEffect(() => {
@@ -27,7 +28,8 @@ function MinicastList(props) {
       const filteredArray = newCastList?.filter(
         (cast) => cast.user_id === creatorID
       );
-      setNewCastList(filteredArray);
+      setNewCastList(filteredArray)
+      setPlaylist(filteredArray);
     } else {
       setNewCastList(minicasts);
     }


### PR DESCRIPTION
Favourites previously had some issues:
-- constant querying to the database, which was fixed by adding a dependency in the useEffect array
-- the browser URL now shows as /users/:userID/favourites rather than just favourites
-- the Playlist (which represents the casts queued for the Player) was out of sync with the minicasts displayed: this was not just a problem with the Favourites view but also the Creator view. Seems to be fixed by allowing these views to setPlaylist.
*** The endpoint for Faves was updated so changes from the server need to be pulled for this to work. ***